### PR TITLE
Remove str/bytes type check for filename; let io.open() do the validity checking.

### DIFF
--- a/backports/lzma/__init__.py
+++ b/backports/lzma/__init__.py
@@ -51,8 +51,8 @@ class LZMAFile(io.BufferedIOBase):
                  format=None, check=-1, preset=None, filters=None):
         """Open an LZMA-compressed file in binary mode.
 
-        filename can be either an actual file name (given as a str or
-        bytes object), in which case the named file is opened, or it can
+        filename can be either an actual file name (given as a str, unicode
+        or bytes object), in which case the named file is opened, or it can
         be an existing file object to read from or write to.
 
         mode can be "r" for reading (default), "w" for (over)writing, or
@@ -121,17 +121,15 @@ class LZMAFile(io.BufferedIOBase):
         else:
             raise ValueError("Invalid mode: {!r}".format(mode))
 
-        if isinstance(filename, (str, bytes)):
+        if hasattr(filename, "read") or hasattr(filename, "write"):
+            self._fp = filename
+            self._mode = mode_code
+        else:
             if "b" not in mode:
                 mode += "b"
             self._fp = io.open(filename, mode)
             self._closefp = True
             self._mode = mode_code
-        elif hasattr(filename, "read") or hasattr(filename, "write"):
-            self._fp = filename
-            self._mode = mode_code
-        else:
-            raise TypeError("filename must be a str or bytes object, or a file")
 
     def close(self):
         """Flush and close the file.

--- a/test/test_lzma.py
+++ b/test/test_lzma.py
@@ -1048,6 +1048,16 @@ class OpenTestCase(unittest.TestCase):
             with lzma.open(TESTFN, "rb") as f:
                 self.assertEqual(f.read(), INPUT * 2)
 
+    def test_unicode_filename(self):
+        if sys.version_info >= (3,):
+            return
+        ufile = unicode(TESTFN)
+        with TempFile(ufile):
+            with lzma.open(ufile, "wb") as f:
+                f.write(INPUT)
+            with lzma.open(ufile, "rb") as f:
+                self.assertEqual(f.read(), INPUT)
+
     def test_bad_params(self):
         # Test invalid parameter combinations.
         self.assertRaises(ValueError, lzma.open,


### PR DESCRIPTION
The use case for this is python2 code that takes advantage of python's automatic transcoding of file names from the file system's character set to Unicode; that allows our python code to not care whether there are special characters in file paths or how they are encoded.
This approach reverses the check inside lzma.open() - if the 'filename' parameter supports a 'read' or 'write' function, treat it as an already opened file, otherwise pass the parameter through to io.open() and let that function throw an error if the parameter is the wrong type.
