### PR TITLE
Declare namespace package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
         'Topic :: System :: Archiving :: Compression',
     ],
     packages = packages,
+    namespace_packages = ['backports'],
     ext_modules = extens,
     cmdclass = {
         'build_ext': build_ext,


### PR DESCRIPTION
This will stop pkg_resources from emitting unsettling warnings like this one:

  /usr/lib/python2.6/site-packages/fedmsg/meta/**init**.py:94: UserWarning:
        Module backports was already imported from
        /usr/lib64/python2.6/site-packages/backports/**init**.pyc, but
        /usr/lib/python2.6/site-packages is being added to sys.path
