### PR TITLE
Declare namespace to setuptools if it is installed.

### DIFF
--- a/backports/__init__.py
+++ b/backports/__init__.py
@@ -3,8 +3,11 @@
 # laid down here: http://pypi.python.org/pypi/backports/1.0
 # Backports homepage: http://bitbucket.org/brandon/backports
 
-# A Python "namespace package" http://www.python.org/dev/peps/pep-0382/
-# This always goes inside of a namespace package's __init__.py
-
-from pkgutil import extend_path
-__path__ = extend_path(__path__, __name__)
+try:
+    # This is a workaround for setuptools that we'll use *if* it is present
+    __import__('pkg_resources').declare_namespace(__name__)
+except ImportError:
+    # Otherwise, use the stdlib way defined in this rejected pep
+    # http://www.python.org/dev/peps/pep-0382/
+    from pkgutil import extend_path
+    __path__ = extend_path(__path__, __name__)


### PR DESCRIPTION
I think this should address the issues from #8.

It is all confusing for a few reasons:

- The setup.py from ``backports.ssl_match_hostnamez`` uses setuptools while the setup.py from ``backports.lzma`` uses distutils.
- The README from the [original backports module](https://pypi.python.org/pypi/backports) suggests that you should use a particular template in the ``backports/__init__.py`` file in reference to a PEP... but that pep [was rejected](http://legacy.python.org/dev/peps/pep-0382/).
- That pep suggests that setuptools provides its own roughly equivalent workaround, one which of course only works with setuptools.

So, in 0f36997 I try first to use the setuptools workaround (which seems to be necessary if setuptools is installed?) and if it is absent, then fall back to the phrase put forward in [pep-0382](http://legacy.python.org/dev/peps/pep-0382).