### PR TITLE
setup.py: Discover liblzma paths via pkg-config.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,9 @@ print("This is backports.lzma version %s" % __version__)
 
 def pkg_config(*args):
     """Call pkg-config and return stdout data on success."""
-    popen = subprocess.Popen(["pkg-config"]  + list(args), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    popen = subprocess.Popen(["pkg-config"]  + list(args),
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            universal_newlines=True)
     stdout, stderr = popen.communicate()
     if popen.wait():
         if stderr:
@@ -47,13 +49,13 @@ def get_include_dirs():
     """Return list of include dirs to use for building."""
     pc_dir = pkg_config("--variable=includedir", "liblzma")
     dirs = [os.path.join(home, 'include'), '/opt/local/include', '/usr/local/include', pc_dir]
-    return filter(None, dirs)
+    return [d for d in dirs if d]
 
 def get_library_dirs():
     """Return list of library dirs to use for building."""
     pc_dir = pkg_config("--variable=libdir", "liblzma")
     dirs = [os.path.join(home, 'lib'), '/opt/local/lib', '/usr/local/lib', pc_dir]
-    return filter(None, dirs)
+    return [d for d in dirs if d]
 
 
 packages = ["backports", "backports.lzma"]


### PR DESCRIPTION
I was unable to build backports.lzma on a RHEL5 system. RHEL5 does not include distribution packages for liblzma, therefore it was installed locally.

The usual way on Linux systems to discover libraries for building is to query the [pkg-config](http://www.freedesktop.org/wiki/Software/pkg-config/) tool. Unfortunately, the setup.py in backports.lzma does not do this yet.

This patch adds pkg-config integration. To stay compatible the pkg-config output is only added as last resort. IMHO it should be the first location to look at, but that's not for me to decide. With this patch backports.lzma builds fine for my case.
