### PR TITLE
Fix 'is32bits' being unportable and completely breaking the build on PyPy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,14 +29,13 @@ print("This is backports.lzma version %s" % __version__)
 
 lzmalib = '%slzma'%('lib' if sys.platform == 'win32' else '')
 
-is32bit = tuple.__itemsize__ == 4
-
 
 class build_ext_subclass(build_ext):
     def build_extensions(self):
         xtra_compile_args = []
 
         if self.compiler.compiler_type == "mingw32":
+            is32bit = tuple.__itemsize__ == 4
             xtra_compile_args = [
                        "-DMS_WIN32",
                        "-mstackrealign"

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ class build_ext_subclass(build_ext):
         xtra_compile_args = []
 
         if self.compiler.compiler_type == "mingw32":
-            is32bit = tuple.__itemsize__ == 4
+            # https://docs.python.org/3/library/platform.html#cross-platform
+            is32bit = sys.maxsize <= 2**32
             xtra_compile_args = [
                        "-DMS_WIN32",
                        "-mstackrealign"


### PR DESCRIPTION
Scope the code only to mingw32 where it is used, and replace it with a portable snippet from CPython documentation instead of the tuple itemsize monstrosity.