### PR TITLE
Check whether filter list is a sequence type explicitly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ python:
   - "pypy3"
 matrix:
   allow_failures:
-  - python: "pypy"
   - python: "pypy3"
   fast_finish: true
 

--- a/backports/lzma/_lzmamodule.c
+++ b/backports/lzma/_lzmamodule.c
@@ -469,6 +469,16 @@ parse_filter_chain_spec(lzma_filter filters[], PyObject *filterspecs)
 {
     Py_ssize_t i, num_filters;
 
+    /* PySequence_Length() is not guaranteed to return error
+       for non-sequence types, and it does not in PyPy.
+       https://bugs.python.org/issue32500
+    */
+    if (PySequence_Check(filterspecs) == 0) {
+        PyErr_Format(PyExc_TypeError,
+                     "Filter list is not of sequence type");
+        return -1;
+    }
+
     num_filters = PySequence_Length(filterspecs);
     if (num_filters == -1)
         return -1;


### PR DESCRIPTION
Add an explicit PySequence_Check() for filter list processing instead of
relying on PySequence_Length() raising a TypeError for dict. This fixes
support for PyPy which successfully returns the dict length.
    
The CPython behavior seems to a bug, as the documentation clearly
states that the call on non-sequence type is equivalent to len(). It
seem more prudent therefore to check for sequence type explicitly.
    
Closes: https://github.com/peterjc/backports.lzma/issues/5