### PR TITLE
Fix namespaces

### DIFF
--- a/backports/__init__.py
+++ b/backports/__init__.py
@@ -6,9 +6,5 @@
 # A Python "namespace package" http://www.python.org/dev/peps/pep-0382/
 # This always goes inside of a namespace package's __init__.py
 
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,6 @@ setup(
         'Topic :: System :: Archiving :: Compression',
     ],
     packages = packages,
-    namespace_packages = ['backports'],
     ext_modules = extens,
     cmdclass = {
         'build_ext': build_ext_subclass,


### PR DESCRIPTION
We need all of the pieces of code to be using the same namespace API in order for it to work properly.  This PR changes all the places that are using setuptools API to use python standard namespaces instead.  That way this package will both work by itself and with the other packages on pypi which are using the backports namespace.