### PR TITLE
Use UTF-8 encoding when reading README.rst in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ extens = [Extension('backports.lzma._lzma',
 descr = "Backport of Python 3.3's 'lzma' module for XZ/LZMA compressed files."
 
 # Load in our reStructuredText README.rst file to pass explicitly in the metadata
-with open("README.rst") as handle:
+with open("README.rst", encoding="UTF-8") as handle:
     long_descr = handle.read()
 
 if sys.version_info < (2,6):

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@
 # This file copyright (c) 2012 Peter Cock, p.j.a.cock@googlemail.com
 # See other files for separate copyright notices.
 
+from io import open
 import sys, os
 from warnings import warn
 


### PR DESCRIPTION
Without this specified, the encoding is system dependent. On some systems (for example, many Docker containers), this ends up as ASCII, and throws an Exception because of the non-ascii names in this file.