### PR TITLE
Use setuptools instead of distutils if available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ addons:
     packages:
     - liblzma-dev
 install:
+  # On nightly, upgrade setuptools first to work around
+  # https://github.com/pypa/setuptools/issues/1257
+  - if [[ $TRAVIS_PYTHON_VERSION == 'nightly' ]]; then travis_retry pip install -U setuptools; fi
   - "python setup.py install"
 before_script:
   - "cd test"

--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,14 @@
 # See other files for separate copyright notices.
 
 import sys, os
-from warnings import warn
 
-from distutils import log
-from distutils.command.build_ext import build_ext
-from distutils.core import setup
-from distutils.extension import Extension
+try:
+    from setuptools.command.build_ext import build_ext
+    from setuptools import setup, Extension
+except ImportError:
+    from distutils.command.build_ext import build_ext
+    from distutils.core import setup
+    from distutils.extension import Extension
 
 # We now extract the version number in backports/lzma/__init__.py
 # We can't use "from backports import lzma" then "lzma.__version__"


### PR DESCRIPTION
We use `backports.lzma` on Windows, and because it requires compilation, we build binary distributions like wheel and egg. In order to create binary distributions we need `setup.py` to use setuptools. This pull request proposes using setuptools if it is available, which is a common approach among python projects (see e.g. [six](https://github.com/benjaminp/six/blob/master/setup.py), [virtualenv](https://github.com/pypa/virtualenv/blob/master/setup.py), [lxml](https://github.com/lxml/lxml/blob/master/setup.py), etc..)