### PR TITLE
Fix conda-forge and defaults badges  [ci skip]

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,11 +2,11 @@
    :alt: Package on Python Package Index (PyPI)
    :target: https://pypi.python.org/pypi/backports.lzma
 .. image:: https://img.shields.io/conda/vn/conda-forge/backports.lzma.svg
-   :alt: Conda package from Anaconda (default) channel
-   :target: https://anaconda.org/anaconda/backports.lzma
-.. image:: https://img.shields.io/conda/vn/anaconda/backports.lzma.svg
    :alt: Conda package from conda-forge channel
    :target: https://anaconda.org/conda-forge/backports.lzma
+.. image:: https://img.shields.io/conda/vn/anaconda/backports.lzma.svg
+   :alt: Conda package from Anaconda (default) channel
+   :target: https://anaconda.org/anaconda/backports.lzma
 .. image:: https://img.shields.io/travis/peterjc/backports.lzma/master.svg
    :alt: Linux testing with TravisCI
    :target: https://travis-ci.org/peterjc/backports.lzma/branches


### PR DESCRIPTION
Things were a little transposed between these two in terms of links and captions. This corrects them.