### PR TITLE
Explicitly use Ubuntu Trusty on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+# Using an old Ubuntu because we want to test with old Pythons
+dist: trusty
 language: python
 python:
   - "2.6"


### PR DESCRIPTION
As of May 2019, TravisCI defaults to Ubuntu Xenial rather than Trusty.
https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment

That unfortunately broke/dropped support for Python 2.6, 3.2 and 3.3
therefore we probably need to stick with the older Ubuntu Trusty explicitly.